### PR TITLE
add support for professional_experience and educational_background

### DIFF
--- a/spring-social-xing/src/main/java/org/springframework/social/xing/api/Award.java
+++ b/spring-social-xing/src/main/java/org/springframework/social/xing/api/Award.java
@@ -1,0 +1,27 @@
+package org.springframework.social.xing.api;
+
+import java.io.Serializable;
+
+/**
+ * Created by json2pojo
+ */
+public class Award implements Serializable {
+
+	private static final long serialVersionUID = -2650314056830306979L;
+	private String name;
+	private Long dateAwarded;
+	private String url;
+
+	public String getName() {
+		return name;
+	}
+
+	public Long getDateAwarded() {
+		return dateAwarded;
+	}
+
+	public Object getUrl() {
+		return url;
+	}
+
+}

--- a/spring-social-xing/src/main/java/org/springframework/social/xing/api/Company.java
+++ b/spring-social-xing/src/main/java/org/springframework/social/xing/api/Company.java
@@ -1,0 +1,64 @@
+package org.springframework.social.xing.api;
+
+import java.io.Serializable;
+
+public class Company implements Serializable {
+
+	private static final long serialVersionUID = 8680835034881540914L;
+	private String id;
+	private String industry;
+	private String companySize;
+	private XingDate endDate;
+	private String tag;
+	private String name;
+	private String url;
+	private String careerLevel;
+	private String title;
+	private XingDate beginDate;
+	private String description;
+
+	public String getId() {
+		return id;
+	}
+
+	public String getIndustry() {
+		return industry;
+	}
+
+	public String getCompanySize() {
+		return companySize;
+	}
+
+	public XingDate getEndDate() {
+		return endDate;
+	}
+
+	public String getTag() {
+		return tag;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String getUrl() {
+		return url;
+	}
+
+	public String getCareerLevel() {
+		return careerLevel;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public XingDate getBeginDate() {
+		return beginDate;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+}

--- a/spring-social-xing/src/main/java/org/springframework/social/xing/api/EducationalBackground.java
+++ b/spring-social-xing/src/main/java/org/springframework/social/xing/api/EducationalBackground.java
@@ -1,0 +1,28 @@
+package org.springframework.social.xing.api;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Created by json2pojo
+ */
+public class EducationalBackground implements Serializable {
+
+	private static final long serialVersionUID = 7273795597965337052L;
+	private School primarySchool;
+	private List<String> qualifications;
+	private List<School> schools;
+
+	public List<String> getQualifications() {
+		return qualifications;
+	}
+
+	public List<School> getSchools() {
+		return schools;
+	}
+
+	public School getPrimarySchool() {
+		return primarySchool;
+	}
+
+}

--- a/spring-social-xing/src/main/java/org/springframework/social/xing/api/ProfessionalExperience.java
+++ b/spring-social-xing/src/main/java/org/springframework/social/xing/api/ProfessionalExperience.java
@@ -1,0 +1,28 @@
+package org.springframework.social.xing.api;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Created by json2pojo
+ */
+public class ProfessionalExperience implements Serializable {
+
+	private static final long serialVersionUID = -2093383150432795268L;
+	private List<Company> nonPrimaryCompanies;
+	private Company primaryCompany;
+	private List<Award> awards;
+
+	public List<Company> getNonPrimaryCompanies() {
+		return nonPrimaryCompanies;
+	}
+
+	public Company getPrimaryCompany() {
+		return primaryCompany;
+	}
+
+	public List<Award> getAwards() {
+		return awards;
+	}
+
+}

--- a/spring-social-xing/src/main/java/org/springframework/social/xing/api/School.java
+++ b/spring-social-xing/src/main/java/org/springframework/social/xing/api/School.java
@@ -1,0 +1,47 @@
+package org.springframework.social.xing.api;
+
+import java.io.Serializable;
+
+/**
+ * Created by json2pojo
+ */
+public class School implements Serializable {
+
+	private static final long serialVersionUID = -2390425436172680486L;
+	private String id;
+	private String subject;
+	private XingDate endDate;
+	private String degree;
+	private String name;
+	private XingDate beginDate;
+	private String notes;
+
+	public String getId() {
+		return id;
+	}
+
+	public String getSubject() {
+		return subject;
+	}
+
+	public XingDate getEndDate() {
+		return endDate;
+	}
+
+	public String getDegree() {
+		return degree;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public XingDate getBeginDate() {
+		return beginDate;
+	}
+
+	public String getNotes() {
+		return notes;
+	}
+
+}

--- a/spring-social-xing/src/main/java/org/springframework/social/xing/api/XingDate.java
+++ b/spring-social-xing/src/main/java/org/springframework/social/xing/api/XingDate.java
@@ -1,0 +1,35 @@
+package org.springframework.social.xing.api;
+
+import java.io.Serializable;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+
+public class XingDate implements Serializable {
+
+	private static final long serialVersionUID = 6747607636067970948L;
+	private Integer year;
+	private Integer month;
+
+	public XingDate(String dateString) {
+		SimpleDateFormat format = new SimpleDateFormat("yyyy-MM");
+		try {
+			Calendar cal = Calendar.getInstance();
+			Date date = format.parse(dateString);
+			cal.setTime(date);
+			month = cal.get(Calendar.MONTH) + 1; // MONTH is zero based
+			year = cal.get(Calendar.YEAR);
+		} catch (ParseException e) {
+			e.printStackTrace();
+		}
+	}
+
+	public Integer getMonth() {
+		return month;
+	}
+
+	public Integer getYear() {
+		return year;
+	}
+}

--- a/spring-social-xing/src/main/java/org/springframework/social/xing/api/XingProfile.java
+++ b/spring-social-xing/src/main/java/org/springframework/social/xing/api/XingProfile.java
@@ -41,6 +41,8 @@ public class XingProfile implements Serializable {
     private String permalink;
     private String activeEmail;
     private String displayName;
+    private ProfessionalExperience professionalExperience;
+    private EducationalBackground educationalBackground;
 
     public XingProfile() {
     }
@@ -157,4 +159,12 @@ public class XingProfile implements Serializable {
     public String getDisplayName() {
         return displayName;
     }
+    
+    public ProfessionalExperience getProfessionalExperience() {
+		return professionalExperience;
+	}
+    
+    public EducationalBackground getEducationalBackground() {
+		return educationalBackground;
+	}
 }

--- a/spring-social-xing/src/main/java/org/springframework/social/xing/api/impl/json/AwardMixin.java
+++ b/spring-social-xing/src/main/java/org/springframework/social/xing/api/impl/json/AwardMixin.java
@@ -1,0 +1,18 @@
+package org.springframework.social.xing.api.impl.json;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Created by json2pojo
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AwardMixin {
+	@JsonProperty("name")
+	private String name;
+	@JsonProperty("date_awarded")
+	private Long dateAwarded;
+	@JsonProperty("url")
+	private Object url;
+
+}

--- a/spring-social-xing/src/main/java/org/springframework/social/xing/api/impl/json/CompanyMixin.java
+++ b/spring-social-xing/src/main/java/org/springframework/social/xing/api/impl/json/CompanyMixin.java
@@ -1,0 +1,34 @@
+package org.springframework.social.xing.api.impl.json;
+
+import org.springframework.social.xing.api.XingDate;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class CompanyMixin {
+	
+	@JsonProperty("id")
+	private String id;
+	@JsonProperty("industry")
+	private String industry;
+	@JsonProperty("company_size")
+	private String companySize;
+	@JsonProperty("end_date")
+	private XingDate endDate;
+	@JsonProperty("tag")
+	private String tag;
+	@JsonProperty("name")
+	private String name;
+	@JsonProperty("url")
+	private String url;
+	@JsonProperty("career_level")
+	private String careerLevel;
+	@JsonProperty("title")
+	private String title;
+	@JsonProperty("begin_date")
+	private XingDate beginDate;
+	@JsonProperty("description")
+	private String description;
+
+}

--- a/spring-social-xing/src/main/java/org/springframework/social/xing/api/impl/json/EducationalBackgroundMixin.java
+++ b/spring-social-xing/src/main/java/org/springframework/social/xing/api/impl/json/EducationalBackgroundMixin.java
@@ -1,0 +1,20 @@
+package org.springframework.social.xing.api.impl.json;
+
+import java.util.List;
+
+import org.springframework.social.xing.api.School;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EducationalBackgroundMixin {
+
+	@JsonProperty("primary_school")
+	private School primarySchool;
+	@JsonProperty("qualifications")
+	private List<String> qualifications;
+	@JsonProperty("schools")
+	private List<School> schools;
+
+}

--- a/spring-social-xing/src/main/java/org/springframework/social/xing/api/impl/json/ProfessionalExperienceMixin.java
+++ b/spring-social-xing/src/main/java/org/springframework/social/xing/api/impl/json/ProfessionalExperienceMixin.java
@@ -1,0 +1,24 @@
+package org.springframework.social.xing.api.impl.json;
+
+import java.util.List;
+
+import org.springframework.social.xing.api.Award;
+import org.springframework.social.xing.api.Company;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Created by json2pojo
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class ProfessionalExperienceMixin {
+
+	@JsonProperty("non_primary_companies")
+	private List<Company> nonPrimaryCompanies;
+	@JsonProperty("awards")
+	private List<Award> awards;
+	@JsonProperty("primary_company")
+	private Company primaryCompany;
+
+}

--- a/spring-social-xing/src/main/java/org/springframework/social/xing/api/impl/json/SchoolMixin.java
+++ b/spring-social-xing/src/main/java/org/springframework/social/xing/api/impl/json/SchoolMixin.java
@@ -1,0 +1,29 @@
+package org.springframework.social.xing.api.impl.json;
+
+import org.springframework.social.xing.api.XingDate;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Created by json2pojo
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SchoolMixin {
+	
+	@JsonProperty("id")
+	private String id;
+	@JsonProperty("subject")
+	private String subject;
+	@JsonProperty("end_date")
+	private XingDate endDate;
+	@JsonProperty("degree")
+	private String degree;
+	@JsonProperty("name")
+	private String name;
+	@JsonProperty("begin_date")
+	private XingDate beginDate;
+	@JsonProperty("notes")
+	private String notes;
+
+}

--- a/spring-social-xing/src/main/java/org/springframework/social/xing/api/impl/json/XingDateMixin.java
+++ b/spring-social-xing/src/main/java/org/springframework/social/xing/api/impl/json/XingDateMixin.java
@@ -1,0 +1,19 @@
+
+package org.springframework.social.xing.api.impl.json;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+abstract class XingDateMixin {
+
+    @JsonCreator
+     XingDateMixin(@JsonProperty("day") Long day,
+                    @JsonProperty("year") Long year,
+                    @JsonProperty("month") Long month) {
+
+    }
+
+}

--- a/spring-social-xing/src/main/java/org/springframework/social/xing/api/impl/json/XingModule.java
+++ b/spring-social-xing/src/main/java/org/springframework/social/xing/api/impl/json/XingModule.java
@@ -16,9 +16,19 @@
 package org.springframework.social.xing.api.impl.json;
 
 
+import org.springframework.social.xing.api.Award;
+import org.springframework.social.xing.api.BirthDate;
+import org.springframework.social.xing.api.BusinessAddress;
+import org.springframework.social.xing.api.Company;
+import org.springframework.social.xing.api.EducationalBackground;
+import org.springframework.social.xing.api.PhotoUrls;
+import org.springframework.social.xing.api.ProfessionalExperience;
+import org.springframework.social.xing.api.XingDate;
+import org.springframework.social.xing.api.XingProfile;
+import org.springframework.social.xing.api.XingProfiles;
+
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import org.springframework.social.xing.api.*;
 
 /**
  * Jackson module for registering mixin annotations against Xing model classes.
@@ -36,6 +46,11 @@ public class XingModule extends SimpleModule {
         context.setMixInAnnotations(BirthDate.class,BirthDateMixin.class);
         context.setMixInAnnotations(PhotoUrls.class,PhotoUrlsMixin.class);
         context.setMixInAnnotations(BusinessAddress.class,BusinessAddressMixin.class);
+        context.setMixInAnnotations(Company.class, CompanyMixin.class);
+        context.setMixInAnnotations(ProfessionalExperience.class, ProfessionalExperienceMixin.class);
+        context.setMixInAnnotations(EducationalBackground.class, EducationalBackgroundMixin.class);
+        context.setMixInAnnotations(XingDate.class, XingDateMixin.class);
+        context.setMixInAnnotations(Award.class, AwardMixin.class);
     }
 
 }

--- a/spring-social-xing/src/main/java/org/springframework/social/xing/api/impl/json/XingProfileMixin.java
+++ b/spring-social-xing/src/main/java/org/springframework/social/xing/api/impl/json/XingProfileMixin.java
@@ -15,44 +15,47 @@
  */
 package org.springframework.social.xing.api.impl.json;
 
+import java.util.List;
+
+import org.springframework.social.xing.api.BirthDate;
+import org.springframework.social.xing.api.BusinessAddress;
+import org.springframework.social.xing.api.PhotoUrls;
+import org.springframework.social.xing.api.ProfessionalExperience;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.springframework.social.xing.api.BirthDate;
-import org.springframework.social.xing.api.BusinessAddress;
-import org.springframework.social.xing.api.PhotoUrls;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 abstract class XingProfileMixin {
 
-    @JsonCreator
-    XingProfileMixin(
-            @JsonProperty("id") String id,
-            @JsonProperty("first_name") String firstName,
-            @JsonProperty("last_name") String lastName,
-            @JsonProperty("permalink") String permalink,
-            @JsonProperty("active_email") String activeEmail,
-            @JsonProperty("display_name") String displayName
-    ) {
-    }
+	@JsonCreator
+	XingProfileMixin(@JsonProperty("id") String id,
+			@JsonProperty("first_name") String firstName,
+			@JsonProperty("last_name") String lastName,
+			@JsonProperty("permalink") String permalink,
+			@JsonProperty("active_email") String activeEmail,
+			@JsonProperty("display_name") String displayName) {
+	}
 
-    @JsonProperty("birth_date")
-    private BirthDate birthDate;
-    @JsonProperty("photo_urls")
-    private PhotoUrls photoUrls;
-    @JsonProperty("interests")
-    private String interests;
-    @JsonProperty("wants")
-    private String wants;
-    @JsonProperty("organisation_member")
-    private String organisationMember;
-    @JsonProperty("gender")
-    private String gender;
-    @JsonProperty("page_name")
-    private String pageName;
-    @JsonProperty("business_address")
-    private BusinessAddress businessAddress;
-    @JsonProperty("haves")
-    private String haves;
+	@JsonProperty("birth_date")
+	private BirthDate birthDate;
+	@JsonProperty("photo_urls")
+	private PhotoUrls photoUrls;
+	@JsonProperty("interests")
+	private String interests;
+	@JsonProperty("wants")
+	private String wants;
+	@JsonProperty("organisation_member")
+	private String organisationMember;
+	@JsonProperty("gender")
+	private String gender;
+	@JsonProperty("page_name")
+	private String pageName;
+	@JsonProperty("business_address")
+	private BusinessAddress businessAddress;
+	@JsonProperty("haves")
+	private String haves;
+	@JsonProperty("professional_experience")
+	private ProfessionalExperience professionalExperience;
 }

--- a/spring-social-xing/src/test/java/org/springframework/social/xing/api/impl/ProfileTemplateTest.java
+++ b/spring-social-xing/src/test/java/org/springframework/social/xing/api/impl/ProfileTemplateTest.java
@@ -44,7 +44,34 @@ public class ProfileTemplateTest extends AbstractXingApiTest {
 		assertEquals("Johannes", userProfile.getFirstName());
 		assertEquals("Bühler", userProfile.getLastName());
         assertThat(userProfile.getPermalink(), is(not(nullValue())));
+        assertThat(userProfile.getProfessionalExperience(), is(not(nullValue())));
+        assertEquals(2, userProfile.getProfessionalExperience().getNonPrimaryCompanies().size());
+        assertEquals("CANOOENGINEERINGAG", userProfile.getProfessionalExperience().getPrimaryCompany().getTag());
+        assertEquals(Integer.valueOf(1), userProfile.getProfessionalExperience().getPrimaryCompany().getBeginDate().getMonth());
+        assertEquals("Senior Software Engineer", userProfile.getProfessionalExperience().getPrimaryCompany().getTitle());
+        assertThat(userProfile.getEducationalBackground(), is(not(nullValue())));
+        assertEquals(2, userProfile.getEducationalBackground().getSchools().size());
+        assertEquals(3, userProfile.getEducationalBackground().getQualifications().size());
+        assertEquals("Java Design Patterns Course Certificate", userProfile.getEducationalBackground().getQualifications().get(2));
+        
 	}
+	
+	
+	@Test
+	public void getFullUserProfile() {
+		mockServer.expect(requestTo(ProfileTemplate.USERS_URL.replaceFirst("\\{id\\}","me"))).andExpect(method(GET))
+				.andRespond(withSuccess(new ClassPathResource("testdata/full_profile.json", getClass()), MediaType.APPLICATION_JSON));
+		XingProfile userProfile = xing.profileOperations().getUserProfile();
+		assertEquals("ACM, GI", userProfile.getOrganisationMember());
+		assertEquals("m", userProfile.getGender());
+		assertEquals("max.mustermann@xing.com", userProfile.getActiveEmail());
+        assertThat(userProfile.getEducationalBackground(), is(not(nullValue())));
+        assertEquals("1_abcdef", userProfile.getProfessionalExperience().getPrimaryCompany().getId());
+        assertEquals("42_abcdef", userProfile.getEducationalBackground().getPrimarySchool().getId());
+        assertEquals(2, userProfile.getEducationalBackground().getQualifications().size());
+        assertEquals("PADI AOWD", userProfile.getEducationalBackground().getQualifications().get(1));
+        
+	}	
 	
 
 	@Test

--- a/spring-social-xing/src/test/java/org/springframework/social/xing/api/impl/testdata/full_profile.json
+++ b/spring-social-xing/src/test/java/org/springframework/social/xing/api/impl/testdata/full_profile.json
@@ -1,0 +1,202 @@
+{
+    "users": [
+        {
+            "id": "123456_abcdef",
+            "first_name": "Max",
+            "last_name": "Mustermann",
+            "display_name": "Max Mustermann",
+            "page_name": "Max_Mustermann",
+            "permalink": "https://www.xing.com/profile/Max_Mustermann",
+            "employment_status": "EMPLOYEE",
+            "gender": "m",
+            "birth_date": {
+                "day": 12,
+                "month": 8,
+                "year": 1963
+            },
+            "active_email": "max.mustermann@xing.com",
+            "time_zone": {
+                "name": "Europe/Copenhagen",
+                "utc_offset": 2
+            },
+            "premium_services": [
+                "SEARCH",
+                "PRIVATEMESSAGES"
+            ],
+            "badges": [
+                "PREMIUM",
+                "MODERATOR"
+            ],
+            "wants": "einen neuen Job",
+            "haves": "viele tolle Skills",
+            "interests": "Flitzebogen schießen and so on",
+            "organisation_member": "ACM, GI",
+            "languages": {
+                "de": "NATIVE",
+                "en": "FLUENT",
+                "fr": null,
+                "zh": "BASIC"
+            },
+            "private_address": {
+                "city": "Hamburg",
+                "country": "DE",
+                "zip_code": "20357",
+                "street": "Privatstraße 1",
+                "phone": "49|40|1234560",
+                "fax": "||",
+                "province": "Hamburg",
+                "email": "max@mustermann.de",
+                "mobile_phone": "49|0155|1234567"
+            },
+            "business_address": {
+                "city": "Hamburg",
+                "country": "DE",
+                "zip_code": "20357",
+                "street": "Geschäftsstraße 1a",
+                "phone": "49|40|1234569",
+                "fax": "49|40|1234561",
+                "province": "Hamburg",
+                "email": "max.mustermann@xing.com",
+                "mobile_phone": "49|160|66666661"
+            },
+            "web_profiles": {
+                "qype": [
+                    "http://qype.de/users/foo"
+                ],
+                "google_plus": [
+                    "http://plus.google.com/foo"
+                ],
+                "blog": [
+                    "http://blog.example.org"
+                ],
+                "homepage": [
+                    "http://example.org",
+                    "http://other-example.org"
+                ]
+            },
+            "instant_messaging_accounts": {
+                "skype": "1122334455",
+                "googletalk": "max.mustermann"
+            },
+            "professional_experience": {
+                "primary_company": {
+                    "id": "1_abcdef",
+                    "name": "XING AG",
+                    "title": "Softwareentwickler",
+                    "company_size": "201-500",
+                    "tag": null,
+                    "url": "http://www.xing.com",
+                    "career_level": "PROFESSIONAL_EXPERIENCED",
+                    "begin_date": "2010-01",
+                    "description": null,
+                    "end_date": null,
+                    "industry": "AEROSPACE",
+                    "form_of_employment": "FULL_TIME_EMPLOYEE",
+                    "until_now": true
+                },
+                "companies": [
+                    {
+                        "id": "1_abcdef",
+                        "name": "XING AG",
+                        "title": "Softwareentwickler",
+                        "company_size": "201-500",
+                        "tag": null,
+                        "url": "http://www.xing.com",
+                        "career_level": "PROFESSIONAL_EXPERIENCED",
+                        "begin_date": "2010-01",
+                        "description": null,
+                        "end_date": null,
+                        "industry": "AEROSPACE",
+                        "form_of_employment": "FULL_TIME_EMPLOYEE",
+                        "until_now": true
+                    },
+                    {
+                        "id": "24_abcdef",
+                        "name": "Ninja Ltd.",
+                        "title": "DevOps",
+                        "company_size": null,
+                        "tag": "NINJA",
+                        "url": "http://www.ninja-ltd.co.uk",
+                        "career_level": null,
+                        "begin_date": "2009-04",
+                        "description": null,
+                        "end_date": "2010-07",
+                        "industry": "ALTERNATIVE_MEDICINE",
+                        "form_of_employment": "OWNER",
+                        "until_now": false
+                    },
+                    {
+                        "id": "45_abcdef",
+                        "name": null,
+                        "title": "Wiss. Mitarbeiter",
+                        "company_size": null,
+                        "tag": "OFFIS",
+                        "url": "http://www.uni.de",
+                        "career_level": null,
+                        "begin_date": "2007",
+                        "description": null,
+                        "end_date": "2008",
+                        "industry": "APPAREL_AND_FASHION",
+                        "form_of_employment": "PART_TIME_EMPLOYEE",
+                        "until_now": false
+                    },
+                    {
+                        "id": "176_abcdef",
+                        "name": null,
+                        "title": "TEST NINJA",
+                        "company_size": "201-500",
+                        "tag": "TESTCOMPANY",
+                        "url": null,
+                        "career_level": "ENTRY_LEVEL",
+                        "begin_date": "1998-12",
+                        "description": null,
+                        "end_date": "1999-05",
+                        "industry": "ARTS_AND_CRAFTS",
+                        "form_of_employment": "INTERN",
+                        "until_now": false
+                    }
+                ],
+                "awards": [
+                    {
+                        "name": "Awesome Dude Of The Year",
+                        "date_awarded": 2007,
+                        "url": null
+                    }
+                ]
+            },
+            "educational_background": {
+                "primary_school": {
+                    "id": "42_abcdef",
+                    "name": "Carl-von-Ossietzky Universtät Schellenburg",
+                    "degree": "MSc CE/CS",
+                    "notes": null,
+                    "subject": null,
+                    "begin_date": "1998-08",
+                    "end_date": "2005-02"
+                },
+                "schools": [
+                    {
+                        "id": "42_abcdef",
+                        "name": "Carl-von-Ossietzky Universtät Schellenburg",
+                        "degree": "MSc CE/CS",
+                        "notes": null,
+                        "subject": null,
+                        "begin_date": "1998-08",
+                        "end_date": "2005-02"
+                    }
+                ],
+                "qualifications": [
+                    "TOEFLS",
+                    "PADI AOWD"
+                ]
+            },
+            "photo_urls": {
+                "large": "http://www.xing.com/img/users/e/3/d/f94ef165a.123456,1.140x185.jpg",
+                "mini_thumb": "http://www.xing.com/img/users/e/3/d/f94ef165a.123456,1.18x24.jpg",
+                "thumb": "http://www.xing.com/img/users/e/3/d/f94ef165a.123456,1.30x40.jpg",
+                "medium_thumb": "http://www.xing.com/img/users/e/3/d/f94ef165a.123456,1.57x75.jpg",
+                "maxi_thumb": "http://www.xing.com/img/users/e/3/d/f94ef165a.123456,1.70x93.jpg"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds more detailes to the user profile, now including professional_experience and educational_background.
I also included some more tests, using an example of a profile having every available field filled with data.
