### PR TITLE
mark "non_primary_companies" as deprecated 

### DIFF
--- a/spring-social-xing/src/main/java/org/springframework/social/xing/api/ProfessionalExperience.java
+++ b/spring-social-xing/src/main/java/org/springframework/social/xing/api/ProfessionalExperience.java
@@ -9,12 +9,22 @@ import java.util.List;
 public class ProfessionalExperience implements Serializable {
 
 	private static final long serialVersionUID = -2093383150432795268L;
+	@Deprecated
 	private List<Company> nonPrimaryCompanies;
+	private List<Company> companies;
 	private Company primaryCompany;
 	private List<Award> awards;
 
+	/**
+	 * deprecated by xing since "2014-05-08"
+	 */
+	@Deprecated
 	public List<Company> getNonPrimaryCompanies() {
 		return nonPrimaryCompanies;
+	}
+	
+	public List<Company> getCompanies() {
+		return companies;
 	}
 
 	public Company getPrimaryCompany() {

--- a/spring-social-xing/src/main/java/org/springframework/social/xing/api/impl/json/ProfessionalExperienceMixin.java
+++ b/spring-social-xing/src/main/java/org/springframework/social/xing/api/impl/json/ProfessionalExperienceMixin.java
@@ -14,6 +14,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonIgnoreProperties(ignoreUnknown = true)
 abstract class ProfessionalExperienceMixin {
 
+	@JsonProperty("companies")
+	private List<Company> companies;
+	/**
+	 * deprecated by xing since "2014-05-08"
+	 */
+	@Deprecated
 	@JsonProperty("non_primary_companies")
 	private List<Company> nonPrimaryCompanies;
 	@JsonProperty("awards")

--- a/spring-social-xing/src/test/java/org/springframework/social/xing/api/impl/ProfileTemplateTest.java
+++ b/spring-social-xing/src/test/java/org/springframework/social/xing/api/impl/ProfileTemplateTest.java
@@ -77,6 +77,7 @@ public class ProfileTemplateTest extends AbstractXingApiTest {
         assertEquals("42_abcdef", userProfile.getEducationalBackground().getPrimarySchool().getId());
         assertEquals(2, userProfile.getEducationalBackground().getQualifications().size());
         assertEquals("PADI AOWD", userProfile.getEducationalBackground().getQualifications().get(1));
+        assertEquals(4, userProfile.getProfessionalExperience().getCompanies().size());
         
 	}	
 	


### PR DESCRIPTION
the field "non_primary_companies" is deprecated by xing since "2014-05-08".
This PR marks the field also as deprecated and introduces the new field "companies" which replaces the former in the xing API
